### PR TITLE
Need to set back to `contents`

### DIFF
--- a/Configuration.yaml
+++ b/Configuration.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAME}
 spec:
   type: ${TYPE}
-  content: ${CONTENT}
+  contents: ${CONTENTS}

--- a/Configuration.yaml
+++ b/Configuration.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAME}
 spec:
   type: ${TYPE}
-  data: ${DATA}
+  content: ${CONTENT}


### PR DESCRIPTION
`data` field is moved to `contents` when the CR is applied. Argo gets confused to determine sync. We need raise this to product team but for now `contents` will do.